### PR TITLE
Fixes typos in posts

### DIFF
--- a/_posts/2013-07-29-getting-60fps-using-devtools.markdown
+++ b/_posts/2013-07-29-getting-60fps-using-devtools.markdown
@@ -88,7 +88,7 @@ to stop the recording.
 You now see the frame data for your page... something like in the snapshot
 above. In the image you'll notice a vertical limit with the label 60 FPS just
 below the label for 30 FPS. These limits are for the frames under which they
-need to do their stuff if the respective framerate is to be acheived. Once you
+need to do their stuff if the respective framerate is to be achieved. Once you
 know this, you'll straight away conclude that almost all of our frames our
 crossing that limit like hell! This is the point where we have actually
 visualized and confirmed the issue. Lets find out the cause.
@@ -108,7 +108,7 @@ script.
 
 Moreover if you hover over any small horizontal yellow bars below, as show in
 the snapshot above, you'll also see the exact time that our scripts are taking
-per frame alongwith the corresponsing event that triggered it. In my case, it's
+per frame along with the corresponding event that triggered it. In my case, it's
 the scroll event (we expected that...no?). Some of those scroll events are
 taking upto *27 ms* which is much much more than our budget of 16ms per frame.
 
@@ -176,7 +176,7 @@ B. Optimize the callback's code to take less execution time
 ### FIX A. Make the Scroll event fire less frequently
 
 I could make the Scroll code fire less frequently in our case as it did not had
-any usabilty hit. In fact mostly the code thats required to be executed on
+any usability hit. In fact mostly the code thats required to be executed on
 Scroll event can be run on little longer intervals without any user experience
 loss.
 
@@ -202,7 +202,7 @@ bar at some distant from each. We'll see.
 ### TEST!
 
 We made a small change from our side. But remember, there is no point of it
-without actually testing the page and getting a performace boost. So lets
+without actually testing the page and getting a performance boost. So lets
 repeat the profiling procedure again.
 
 Here is what we got this time:
@@ -217,7 +217,7 @@ Seems to have worked quite a bit! We have lesser frames overshooting the 16ms bu
 
 Secondly, its also important to optimize the code inside that callback at that is what is causing the frames to go beyond our 16ms budget.
 
-If you look closely inside the callback's code and have a basic understanding of what not do while jQuery, you'll see some horibble things happening there. I'll not go in much details on why those things are bad as our focus is on using devtools in this article. Lets list out what all jQuery menace we see in it:
+If you look closely inside the callback's code and have a basic understanding of what not do while jQuery, you'll see some horrible things happening there. I'll not go in much details on why those things are bad as our focus is on using devtools in this article. Lets list out what all jQuery menace we see in it:
 
 - Cache jQuery objects
 

--- a/_posts/2013-09-2-scaling-with-queues.markdown
+++ b/_posts/2013-09-2-scaling-with-queues.markdown
@@ -58,7 +58,7 @@ which could publish messages to a RabbitMQ broker over STOMP protocol. The libra
 opensourced for the hacker [community](https://groups.google.com/forum/?fromgroups#!forum/openresty-en).
 
 Later, I rewrote our Lua handler code using this library and ran a [loader.io](http://loader.io)
-load test. It failed this model due to very [low throughtput](http://ldr.io/154Xf1h),
+load test. It failed this model due to very [low throughput](http://ldr.io/154Xf1h),
 we performed a load test on a small 1G DigitalOcean instance for both models.
 For us, the STOMP protocol
 and slow RabbitMQ STOMP adapter were performance bottlenecks. RabbitMQ was not

--- a/_posts/2013-11-26-e2e-testing-with-webdriverjs-jasmine.markdown
+++ b/_posts/2013-11-26-e2e-testing-with-webdriverjs-jasmine.markdown
@@ -80,7 +80,7 @@ driver.get(page1);
 driver.click(E1);
 {% endhighlight %}
 
-Both statments would have executed synchronously as the Python (as every other language) API is blocking. But that isn't the case with JavaScript. To maintain the required sequence between various actions, WebDriverJS uses [Promises](https://code.google.com/p/selenium/source/browse/javascript/webdriver/promise.js). In short, a promise is an object that can execute whatever you give it after it has finished.
+Both statements would have executed synchronously as the Python (as every other language) API is blocking. But that isn't the case with JavaScript. To maintain the required sequence between various actions, WebDriverJS uses [Promises](https://code.google.com/p/selenium/source/browse/javascript/webdriver/promise.js). In short, a promise is an object that can execute whatever you give it after it has finished.
 
 But it doesn't stop here. Even with promises, the above code would have become:
 
@@ -225,7 +225,7 @@ e2e testing is important for the apps being written today and hence it becomes i
 
 Hope this helps you get started. So what are you waiting for, lets write some end-to-end tests!
 
-Using a e2e testing stack you want to share? Let us know in the comments.
+Using an e2e testing stack you want to share? Let us know in the comments.
 
 ## Links & references
 

--- a/_posts/2014-06-13-fast-storage-with-rocksdb.markdown
+++ b/_posts/2014-06-13-fast-storage-with-rocksdb.markdown
@@ -42,7 +42,7 @@ Cassandra. In clustered deployment, reads from Cassandra were too slow and slowe
 when data size would grew. After understanding how Cassandra worked under the
 hood such as its log structured storage like LevelDB I started playing with opensource
 embeddable databases that would use similar approach such as LevelDB and Kyoto Cabinet.
-At the time, I found an embedabble persistent key-value store
+At the time, I found an embeddable persistent key-value store
 library built on LevelDB called [RocksDB](http://rocksdb.org).
 It was opensourced by Facebook and had a fairly active developer community so I
 started [playing](https://github.com/facebook/rocksdb/tree/master/examples)

--- a/_posts/2014-08-02-wingify-at-the-fifth-elephant.markdown
+++ b/_posts/2014-08-02-wingify-at-the-fifth-elephant.markdown
@@ -52,7 +52,7 @@ In the process, we had good some good discussions and connected with good people
 
 We have not always been very focussed at doing a lot with collected data. With our latest release, we have come up with a number of features that make use of large amount of data our systems collect and our solutions to these problems were rather unconventional. With the latest release and our plans, we will be making more and more use of collected data for deriving useful insights for our customers and building new features that will help our customers optimize and increase their conversions. Since we have plans to work with data, The Fifth Elephant was an important conference for us to learn about what exactly is going on in the Big Data universe and how we can make use of all that at Wingify. Aerospike NoSQL Database, Cachebox, Imobi's Grill project are just a few things that we got introduced to and we may explore them in the future for our varied use-cases. It was interesting to see people are trying to leverage SSDs for solving different kind of problems. Aerospike is a NoSQL database optimized for SSD disks and claims to be extremely performant (200,000 QPS per node). CacheBox is an advanced caching solution that leverages flash storage for improving performance for databases.
 
-Other than these systems, there were some learning around building big data infrastructure, real-time data pipelines and data mining. There was a talk on [Lessons from Elasticsearch in Production][12] by [Swaroop CH][13] from [Helpshift][14]. We have been using Elasticsearch at Wingify and it was interesting to see that we were not facing similar problems as they were. We took that as a sign to be cautious and be prepared for firfighting such problems. These were around using Elasticsearch's Snapshot and Restore API (they say it doesn't work) and performing rolling upgrades (which is the recommended way of doing upgrades). We never had such problems but we are now aware that others have had such problems and we can be better prepared.
+Other than these systems, there were some learning around building big data infrastructure, real-time data pipelines and data mining. There was a talk on [Lessons from Elasticsearch in Production][12] by [Swaroop CH][13] from [Helpshift][14]. We have been using Elasticsearch at Wingify and it was interesting to see that we were not facing similar problems as they were. We took that as a sign to be cautious and be prepared for firefighting such problems. These were around using Elasticsearch's Snapshot and Restore API (they say it doesn't work) and performing rolling upgrades (which is the recommended way of doing upgrades). We never had such problems but we are now aware that others have had such problems and we can be better prepared.
 
 ## To sum up
 
@@ -62,7 +62,7 @@ If you were present at the conference and met us there, please do not hesitate t
 
 ### Photo Credits
 
-The beautiful photopgraphs in this post have been provided by [HasGeek][17]. You can find more photographs of The Fifth Elephant at the following links:
+The beautiful photographs in this post have been provided by [HasGeek][17]. You can find more photographs of The Fifth Elephant at the following links:
 
 * [Conference Day 1][18]
 * [Conference Day 2][19]

--- a/_posts/2014-08-11-open-sourcing-dom-comparator.markdown
+++ b/_posts/2014-08-11-open-sourcing-dom-comparator.markdown
@@ -65,7 +65,7 @@ Notice how this would not only add the styles to that element, but also change i
 
 ## DOM Comparator to the Rescue
 
-With DOM Comparator in place, the initial markup of the Edit operation above will be compared with the final one, and a differencewould be returned. The difference would contain the minimal changes necessary to be made to the target element, thereby impacting dynamic content as less as possible.
+With DOM Comparator in place, the initial markup of the Edit operation above will be compared with the final one, and a difference would be returned. The difference would contain the minimal changes necessary to be made to the target element, thereby impacting dynamic content as less as possible.
 
 For the above example, here's what the list of resulting operations would look like:
 

--- a/_posts/2014-08-25-jsfoo-run-up-event.markdown
+++ b/_posts/2014-08-25-jsfoo-run-up-event.markdown
@@ -12,7 +12,7 @@ Our single-page application, [VWO](http://vwo.com), is powered by a nifty combin
 
 ## Sponsoring JSFoo
 
-For the very reason of community involvement being indespensable for better development, we are sponsoring JSFoo 2014 in Bangalore this year. Our engineers will be present at the conference. Should you be interested in our work, and would like to know more about what we do, want to work with us, or just want to say Hi!, drop by our booth (B1), or catch any of our team members at the event.
+For the very reason of community involvement being indispensable for better development, we are sponsoring JSFoo 2014 in Bangalore this year. Our engineers will be present at the conference. Should you be interested in our work, and would like to know more about what we do, want to work with us, or just want to say Hi!, drop by our booth (B1), or catch any of our team members at the event.
 
 ## JSFoo Run-up Event (Delhi)
 
@@ -49,7 +49,7 @@ Let the submissions begin!
 
 ### Rules
 
-1. The deadline for the compeition is 20th September 2014, 23:59 IST.
+1. The deadline for the competition is 20th September 2014, 23:59 IST.
 2. Your entry should use Javascript, HTML5 Canvas and Squares to create something visually appealing.
 3. CoffeeScript is allowed.
 4. Judgement will primarily be based on visual appeal. Secondary parameters include code quality and smoothness.

--- a/_posts/2014-09-08-jsfoo-run-up-event-details.markdown
+++ b/_posts/2014-09-08-jsfoo-run-up-event-details.markdown
@@ -10,7 +10,7 @@ Last week, we announced that Wingify would be sponsoring the [JSFoo 2014](http:/
 
 Since it was the first time we hosted such a big event, we were both excited and nervous. We had started preparing for the event about a month in advance. To market the event, we spread out information about the event on meetup groups we were connected with, and also created a [Facebook event](https://www.facebook.com/events/1464410987176966/ ) for it. In total, we received about 100-120 signups for the event. Of all the signups, we expected about one-third of them to actually turn up for the event, for whom we started to arrange for food and logistics.
 
-What’s exciting is that more than 50 external external guests from 30 different companies and colleges showed up. We were really humbled with such great turnout and would like to thank each one of you who joined us for the event.
+What’s exciting is that more than 50 external guests from 30 different companies and colleges showed up. We were really humbled with such great turnout and would like to thank each one of you who joined us for the event.
 
 The event started on time (10:30am) with [Suchit Puri](https://twitter.com/suchitpuri) taking the stage. He welcomed us to the event and introduced the first speaker [Rudi M.K.](https://github.com/rudimk), who was about to speak on **“A new approach to scientific computing using JavaScript“**. He talked about the possibilities of using JavaScript for mathematical and scientific computing. He had a few examples of using JavaScript on the server side for complex mathematical computation. It was really enlightening to see so many libraries coming up in support of scientific computing in the  JavaScript ecosystem.
 

--- a/_posts/2015-01-29-performance-testing.markdown
+++ b/_posts/2015-01-29-performance-testing.markdown
@@ -28,7 +28,7 @@ In single-page apps, the performance equally depends on both the client-side and
 
 Since single-page apps are Javascript/Ajax enabled, measuring performance from server/API level is not enough. Even poorly written javascript code can majorly affect the performance of the app.
 
-Client-side performance testing can also be done using popular tools like [Google Page Speed](https://developers.google.com/speed/pagespeed/) or [Webpagetest.org](http://webpagetest.org). But they cannot test different modules of the application seperately. They'd just test the URLs you enter. To test different sections of your application, we can follow a different appraoch. 
+Client-side performance testing can also be done using popular tools like [Google Page Speed](https://developers.google.com/speed/pagespeed/) or [Webpagetest.org](http://webpagetest.org). But they cannot test different modules of the application separately. They'd just test the URLs you enter. To test different sections of your application, we can follow a different approach. 
 
 In this blog post, I’m going to show you how to use the most popular open-source tool (JMeter)[http://jmeter.apache.org/] to performance test AJAX-enabled websites.
 
@@ -60,7 +60,7 @@ Simply add the following to your test plan:
 
 ![](/images/2015/01/01.png)
 
-Now add the following Javacript code in WebDriver Sampler
+Now add the following JavaScript code in WebDriver Sampler
 
 {% highlight js %}
 WDS.sampleResult.sampleStart();

--- a/_posts/2015-02-13-angularapp-e2e-testing-with-protractor.markdown
+++ b/_posts/2015-02-13-angularapp-e2e-testing-with-protractor.markdown
@@ -241,7 +241,7 @@ element(by.model('Url')).sendkeys('http://').then(function (ele){
 });
 {% endhighlight %}
 
-- Never use protractor element statments inside loop: The simple reason is that the webdriverJS (protractor) API is asynchronus. Element statements returns a promise and that promise is in unresolved state while the code below the statements continues to execute. This leads to unpredicatble results. Hence, it is advisable to use recursive functions instead of loops.
+- Never use protractor element statements inside loop: The simple reason is that the webdriverJS (protractor) API is asynchronous. Element statements returns a promise and that promise is in unresolved state while the code below the statements continues to execute. This leads to unpredictable results. Hence, it is advisable to use recursive functions instead of loops.
 
 - Debug the tests using elementexplorer.js: elementexplorer.js lets you test the page interactively. You will find this JS file in node_modules/protractor/bin directory. Start the selenium server and run command:
 
@@ -251,7 +251,7 @@ node elementexplorer https://app.vwo.com
 
 Browser will load the URL and you will see > prompt. Use browser, element and protractor variables to interact with page.
 
-**Note:** Make sure that the developer tools are closed while running commmands in elementexplorer.js prompt, otherwise you will face an unexpected error as **"TypeError: Cannot read property 'click' of null"**
+**Note:** Make sure that the developer tools are closed while running commands in elementexplorer.js prompt, otherwise you will face an unexpected error as **"TypeError: Cannot read property 'click' of null"**
 
 ### Maintaining and reusing test cases
 

--- a/_posts/2015-06-01-post-meta-refresh-run-up.markdown
+++ b/_posts/2015-06-01-post-meta-refresh-run-up.markdown
@@ -22,7 +22,7 @@ The event started on time (10:30am) with Tony introducing MetaRefresh, HasGeek a
   </div>
 </div>
 
-A pure technical talk related to web performance, started off with a poll to find out how many of the participants measure performance regularly and have it part of their deployment process, the feedback from the attendees depicted negligible measures taken to continously monitor product performance. Next was the discussion of the reasons on why performance mattered, which was followed up with the discussion of various hacks that people employed to bring performance to their applications. The core part of this talk discussed the difference between using hacks versus following different approach during development, and how each of them paid in the long run.
+A pure technical talk related to web performance, started off with a poll to find out how many of the participants measure performance regularly and have it part of their deployment process, the feedback from the attendees depicted negligible measures taken to continuously monitor product performance. Next was the discussion of the reasons on why performance mattered, which was followed up with the discussion of various hacks that people employed to bring performance to their applications. The core part of this talk discussed the difference between using hacks versus following different approach during development, and how each of them paid in the long run.
 
 Slides: [www.slideshare.net/ApoorvSaxena/hacking-to-be-performant](http://www.slideshare.net/ApoorvSaxena/hacking-to-be-performant)
 

--- a/_posts/2015-10-07-superlelasticsearch.markdown
+++ b/_posts/2015-10-07-superlelasticsearch.markdown
@@ -38,7 +38,7 @@ us were:
 2. Un-opinionated
 3. Simple design
 
-Considering all all these factors, we decided to go with the Official Python
+Considering all these factors, we decided to go with the Official Python
 Client for Elasticsearch. And we didn't really come across any issues and
 problems according to our simple requirements. It is fairly extensible and
 comes with some standard batteries included with it. For everything else, you


### PR DESCRIPTION
Came across a bunch of typos while reading the blog. So thought to create a PR for the same -

Here is a more detailed log of the changes done

In `_posts/2015-10-07-superlelasticsearch.markdown`

1. Remove extra all

In `_posts/2015-06-01-post-meta-refresh-run-up.markdown`

2. Spelling mistake - continously > continuously

In `_posts/2015-02-13-angularapp-e2e-testing-with-protractor.markdown`

3. Spelling mistake - statments > statements
4. Spelling mistake - asynchronus > asynchronous
5. Spelling mistake - unpredicatble > unpredictable
6. Spelling mistake - commmands > commands

In `_posts/2015-01-29-performance-testing.markdown`

7. Spelling mistake - seperately > separately
8. Spelling mistake - appraoch > approach
9. Spelling mistake - Javacript > JavaScript

In `_posts/2014-09-08-jsfoo-run-up-event-details.markdown`

10. Remove extra external

In `_posts/2014-08-25-jsfoo-run-up-event.markdown`

11. Spelling mistake - indespensable > indispensable
12. Spelling mistake - compeition > competition

In `_posts/2014-08-11-open-sourcing-dom-comparator.markdown`

13. Add space between difference and would

In `_posts/2014-08-02-wingify-at-the-fifth-elephant.markdown`

14. Spelling mistake - firfighting > firefighting
15. Spelling mistake - photopgraphs > photographs

In `_posts/2014-06-13-fast-storage-with-rocksdb.markdown`

16. Spelling mistake - embedabble > embeddable

In `_posts/2013-11-26-e2e-testing-with-webdriverjs-jasmine.markdown`

17. Spelling mistake - statments > statements
18. Replace a with an

In `_posts/2013-09-2-scaling-with-queues.markdown`

19. Spelling mistake - throughtput > throughput

In `_posts/2013-07-29-getting-60fps-using-devtools.markdown`

20. Spelling mistake - acheived > achieved
21. Add space between along and with
22. Spelling mistake - corresponsing > corresponding
23. Spelling mistake - usabilty > usability
24. Spelling mistake - performace > performance
25. Spelling mistake - horibble > horrible